### PR TITLE
feat: new benchmark MathVision

### DIFF
--- a/eval_anything/benchmarks/__init__.py
+++ b/eval_anything/benchmarks/__init__.py
@@ -11,6 +11,7 @@ benchmark_modules = [
     "benchmarks.text_to_text.MMLUPRO.eval",
     "benchmarks.text_to_text.CEval.eval",
     "benchmarks.text_image_to_text.mmmu.eval",
+    "benchmarks.text_image_to_text.mathvision.eval",
 ]
 
 for module in benchmark_modules:

--- a/eval_anything/benchmarks/text_image_to_text/mathvision/configs.yaml
+++ b/eval_anything/benchmarks/text_image_to_text/mathvision/configs.yaml
@@ -1,0 +1,51 @@
+# ============================================
+# 评测配置：
+#   - 数据集hf路径
+#   - 数据集split
+#   - 数据集size
+#   - 数据集模态
+#   - 评测方式（multiple choice / generation / ...）
+#   - 评测指标（accuracy / ...）
+#   - 是否支持few_shot
+#   - 选项编号形式（ABCD或1234...），判断对错时的标识(true/false或者1/0...)
+# ============================================
+dataset:
+  name: mathvision
+  path: MathLLMs/MathVision
+  split: test
+  size: 
+  modality: text-image-to-text
+  fewshot_data_path: null
+  fewshot_data_name: null
+  fewshot_data_split: null
+  cot_fewshot_data_path: null
+  cot_fewshot_data_name: null
+  cot_fewshot_data_split: null
+  max_shot: 0
+  default_task_list: ["default"]
+task_defaults: &task_defaults
+  type: MultiChoice
+  question_key: question
+  answer_key: options
+  ground_truth_key: answer
+  candidate_labels: ["A", "B", "C", "D", "E"]
+  avalable_evaluate_tools: ["match_multi-choice_and_open-ended"]
+task: 
+  - name: default
+    data_files: null
+    <<: *task_defaults
+answer_extractor:
+  - name: match_multi-choice_and_open-ended
+    function: regex_match_latex_math
+    args:
+      match_index: -1   # Index for multiple choice
+metrics:
+  - name: accuracy
+    function: accuracy
+    args:
+overall_metrics:
+  - name: average
+    function: average_across_tasks
+    args:
+      null
+  

--- a/eval_anything/benchmarks/text_image_to_text/mathvision/eval.py
+++ b/eval_anything/benchmarks/text_image_to_text/mathvision/eval.py
@@ -23,8 +23,6 @@ class mathvisionBenchmark(MMUndBenchmark):
         self.benchmark_name = "mathvision"
         self.benchmark_cfgs = self.get_benchmark_cfgs(self.benchmark_name)
 
-
-
     def run(self, 
             task_list: list[str],) -> tuple[dict[str, list[EvaluationResult]], dict[str, dict[str, float]], dict[str, dict[str, float]]]:
         """Run benchmark

--- a/eval_anything/benchmarks/text_image_to_text/mathvision/eval.py
+++ b/eval_anything/benchmarks/text_image_to_text/mathvision/eval.py
@@ -1,0 +1,61 @@
+"""
+继承自eval-anything.pipeline.mm_und_benchmark
+"""
+from eval_anything.pipeline.mm_und_benchmark import MMUndBenchmark
+from collections import namedtuple
+from eval_anything.utils.data_type import EvaluationResult
+from eval_anything.models.base_model import BaseModel
+from eval_anything.utils.logger import EvalLogger
+from eval_anything.utils.register import BenchmarkRegistry
+from eval_anything.utils.cache_manager import CacheManager
+
+@BenchmarkRegistry.register('mathvision')
+class mathvisionBenchmark(MMUndBenchmark):
+    def __init__(self, 
+                 model: BaseModel, 
+                 eval_cfgs: namedtuple, 
+                 model_cfgs: namedtuple, 
+                 infer_cfgs: namedtuple, 
+                 output_path: str,
+                 cache_manager: CacheManager,
+                 logger: EvalLogger):
+        super().__init__(model, eval_cfgs, model_cfgs, infer_cfgs, output_path, cache_manager, logger)
+        self.benchmark_name = "mathvision"
+        self.benchmark_cfgs = self.get_benchmark_cfgs(self.benchmark_name)
+
+
+
+    def run(self, 
+            task_list: list[str],) -> tuple[dict[str, list[EvaluationResult]], dict[str, dict[str, float]], dict[str, dict[str, float]]]:
+        """Run benchmark
+        Args:
+            task_list (list[str]): task list
+            
+        Returns:
+            evaluation_details (dict[str, list[EvaluationResult]]): evaluation details
+            evaluation_results (dict[str, dict[str, float]]): evaluation results
+        """
+
+        self.logger.log('info', f'Evaluating {self.benchmark_name}...')
+
+        dataloader = self.init_dataloader(self.eval_cfgs, self.benchmark_cfgs)
+        input_data = dataloader.load_dataset(task_list)    # Input_data: list[InferenceInput]
+
+        inference_outputs = self.batch_inference(self.model, input_data)
+        ref_answers = {task: self.get_ref_answer(input_data[task], inference_outputs[task]) for task in task_list}
+        evaluation_details = {}
+        evaluation_results = {}
+
+        for task in task_list:
+            evaluation_details[task], evaluation_results[task] = self.calculate_metrics(self.benchmark_name, inference_outputs[task], ref_answers[task], self.benchmark_cfgs.answer_extractor, self.benchmark_cfgs.metrics, judge_method="judge_latex_equal")
+
+        if len(task_list) > 1:
+            overall_result = self.calculate_overall_metrics(self.benchmark_cfgs.overall_metrics, result=evaluation_results)
+        else:
+            overall_result = {}
+
+        self.display_benchmark_results(self.benchmark_name, evaluation_results)
+        if overall_result != {}:
+            self.display_benchmark_results(self.benchmark_name, overall_result)
+        self.save_benchmark_details(self.output_path, self.benchmark_name, input_data, evaluation_details)
+        return evaluation_details, evaluation_results, overall_result

--- a/eval_anything/configs/evaluate.yaml
+++ b/eval_anything/configs/evaluate.yaml
@@ -52,24 +52,24 @@
     visualization:
       enable: false
       port: 8080
-      share: falsenum_gpu
+      share: false
   # The model configurations
   model_cfgs:
     # Pretrained model unique identity
-    model_id: Qwen/Qwen2.5-VL-72B-Instruct
+    model_id: Llava-1.5-7B-HF
     # Pretrained model name or path  Qwen/Qwen2.5-VL-7B-Instruct  /aifs4su/yaodong/models/llava-1.5-7b-hf
-    model_name_or_path: Qwen/Qwen2.5-VL-72B-Instruct
+    model_name_or_path: /aifs4su/yaodong/models/llava-1.5-7b-hf
     # Model type ("LM" or "MM")
     model_type: "MM"
     # Chat template
-    chat_template: Qwen2-VL
+    chat_template: Llava
   infer_cfgs:
     # Inference backend
     infer_backend: "vllm"
     # Whether to trust remote code
     trust_remote_code: True
     # The max token length
-    model_max_length: 1024
+    model_max_length: 2048
     # The max new tokens
     max_new_tokens: 512
     # The number of Output
@@ -77,7 +77,7 @@
     # Top-K
     top_k: 50
     # Top-P
-    top_p: 0.001
+    top_p: 0.95
     # Temperature
     temperature: 0.1
     # Prompt Logprobs
@@ -93,5 +93,5 @@
     # Available GPU IDs. If not specified, first num_gpu GPUs will be used.
     gpu_ids: [0,1,2,3,4,5,6,7]
     # GPU utilization
-    gpu_utilization: 0.5
+    gpu_utilization: 0.8
     

--- a/eval_anything/configs/evaluate.yaml
+++ b/eval_anything/configs/evaluate.yaml
@@ -16,8 +16,9 @@
       "ARC": ["ARC-Challenge", "ARC-Easy"],
       "CMMLU": ['agronomy', 'anatomy', 'ancient_chinese', 'arts', 'astronomy', 'business_ethics', 'chinese_civil_service_exam', 'chinese_driving_rule', 'chinese_food_culture', 'chinese_foreign_policy', 'chinese_history', 'chinese_literature', 'chinese_teacher_qualification', 'clinical_knowledge', 'college_actuarial_science', 'college_education', 'college_engineering_hydrology', 'college_law', 'college_mathematics', 'college_medical_statistics', 'college_medicine', 'computer_science', 'computer_security', 'conceptual_physics', 'construction_project_management', 'economics', 'education', 'electrical_engineering', 'elementary_chinese', 'elementary_commonsense', 'elementary_information_and_technology', 'elementary_mathematics', 'ethnology', 'food_science', 'genetics', 'global_facts', 'high_school_biology', 'high_school_chemistry', 'high_school_geography', 'high_school_mathematics', 'high_school_physics', 'high_school_politics', 'human_sexuality', 'international_law', 'journalism', 'jurisprudence', 'legal_and_moral_basis', 'logical', 'machine_learning', 'management', 'marketing', 'marxist_theory', 'modern_chinese', 'nutrition', 'philosophy', 'professional_accounting', 'professional_law', 'professional_medicine', 'professional_psychology', 'public_relations', 'security_study', 'sociology', 'sports_science', 'traditional_chinese_medicine', 'virology', 'world_history', 'world_religions'],
       "MMLUPRO": ["default"],
-      "CEval": ['accountant', 'advanced_mathematics', 'art_studies', 'basic_medicine', 'business_administration', 'chinese_language_and_literature', 'civil_servant', 'clinical_medicine', 'college_chemistry', 'college_economics', 'college_physics', 'college_programming', 'computer_architecture', 'computer_network', 'discrete_mathematics', 'education_science', 'electrical_engineer', 'environmental_impact_assessment_engineer', 'fire_engineer', 'high_school_biology', 'high_school_chemistry', 'high_school_chinese', 'high_school_geography', 'high_school_history', 'high_school_mathematics', 'high_school_physics', 'high_school_politics', 'ideological_and_moral_cultivation', 'law', 'legal_professional', 'logic', 'mao_zedong_thought', 'marxism', 'metrology_engineer', 'middle_school_biology', 'middle_school_chemistry', 'middle_school_geography', 'middle_school_history', 'middle_school_mathematics', 'middle_school_physics', 'middle_school_politics', 'modern_chinese_history', 'operating_system', 'physician', 'plant_protection', 'probability_and_statistics', 'professional_tour_guide', 'sports_science', 'tax_accountant', 'teacher_qualification', 'urban_and_rural_planner', 'veterinary_medicine']
+      "CEval": ['accountant', 'advanced_mathematics', 'art_studies', 'basic_medicine', 'business_administration', 'chinese_language_and_literature', 'civil_servant', 'clinical_medicine', 'college_chemistry', 'college_economics', 'college_physics', 'college_programming', 'computer_architecture', 'computer_network', 'discrete_mathematics', 'education_science', 'electrical_engineer', 'environmental_impact_assessment_engineer', 'fire_engineer', 'high_school_biology', 'high_school_chemistry', 'high_school_chinese', 'high_school_geography', 'high_school_history', 'high_school_mathematics', 'high_school_physics', 'high_school_politics', 'ideological_and_moral_cultivation', 'law', 'legal_professional', 'logic', 'mao_zedong_thought', 'marxism', 'metrology_engineer', 'middle_school_biology', 'middle_school_chemistry', 'middle_school_geography', 'middle_school_history', 'middle_school_mathematics', 'middle_school_physics', 'middle_school_politics', 'modern_chinese_history', 'operating_system', 'physician', 'plant_protection', 'probability_and_statistics', 'professional_tour_guide', 'sports_science', 'tax_accountant', 'teacher_qualification', 'urban_and_rural_planner', 'veterinary_medicine'],
       "mmmu": ["Accounting"],
+      "mathvision": ["default"],
       }
     # Num shot
     n_shot: {
@@ -31,6 +32,7 @@
       "MMLUPRO": 8,
       "CEval": 5,
       "mmmu": 5,
+      "mathvision": 0,
       }
     # Chain of thought
     cot: {
@@ -44,29 +46,30 @@
       "MMLUPRO": True,
       "CEval": False,
       "mmmu": False,
+      "mathvision": False,
       }
     # Visualization
     visualization:
       enable: false
       port: 8080
-      share: false
+      share: falsenum_gpu
   # The model configurations
   model_cfgs:
     # Pretrained model unique identity
-    model_id: Llava-1.5-7B-HF
-    # Pretrained model name or path
-    model_name_or_path: /aifs4su/yaodong/models/llava-1.5-7b-hf
+    model_id: Qwen/Qwen2.5-VL-72B-Instruct
+    # Pretrained model name or path  Qwen/Qwen2.5-VL-7B-Instruct  /aifs4su/yaodong/models/llava-1.5-7b-hf
+    model_name_or_path: Qwen/Qwen2.5-VL-72B-Instruct
     # Model type ("LM" or "MM")
     model_type: "MM"
     # Chat template
-    chat_template: Llava
+    chat_template: Qwen2-VL
   infer_cfgs:
     # Inference backend
     infer_backend: "vllm"
     # Whether to trust remote code
     trust_remote_code: True
     # The max token length
-    model_max_length: 2048
+    model_max_length: 1024
     # The max new tokens
     max_new_tokens: 512
     # The number of Output
@@ -74,9 +77,9 @@
     # Top-K
     top_k: 50
     # Top-P
-    top_p: 0.95
+    top_p: 0.001
     # Temperature
-    temperature: 0.
+    temperature: 0.1
     # Prompt Logprobs
     prompt_logprobs: 0
     # Logprobs
@@ -90,5 +93,5 @@
     # Available GPU IDs. If not specified, first num_gpu GPUs will be used.
     gpu_ids: [0,1,2,3,4,5,6,7]
     # GPU utilization
-    gpu_utilization: 0.8
+    gpu_utilization: 0.5
     

--- a/eval_anything/configs/evaluate.yaml
+++ b/eval_anything/configs/evaluate.yaml
@@ -57,7 +57,7 @@
   model_cfgs:
     # Pretrained model unique identity
     model_id: Llava-1.5-7B-HF
-    # Pretrained model name or path  Qwen/Qwen2.5-VL-7B-Instruct  /aifs4su/yaodong/models/llava-1.5-7b-hf
+    # Pretrained model name or path
     model_name_or_path: /aifs4su/yaodong/models/llava-1.5-7b-hf
     # Model type ("LM" or "MM")
     model_type: "MM"
@@ -79,7 +79,7 @@
     # Top-P
     top_p: 0.95
     # Temperature
-    temperature: 0.1
+    temperature: 0.
     # Prompt Logprobs
     prompt_logprobs: 0
     # Logprobs

--- a/eval_anything/evaluate_tools/t2t_tools.py
+++ b/eval_anything/evaluate_tools/t2t_tools.py
@@ -4,6 +4,8 @@ Evaluation tools package (including calculation of various metrics and extractio
 from abc import ABC, abstractmethod
 from eval_anything.evaluate_tools.base_tools import BaseTool
 from typing import Union, List, Iterable, Optional
+from latex2sympy2 import latex2sympy
+from math import *
 import numpy as np
 import re
 
@@ -14,11 +16,13 @@ T2T_EXTRACTOR_MAP = {
     "regex_match_code": "RegexMatchCode",
     "regex_match_math": "RegexMatchMath",
     "regex_match_multi_open": "RegexMatchMultiOpen",
+    "regex_match_latex_math" : "RegexMatchLatexMath"
 }
 
 T2T_JUDGER_MAP = {
     "judge_equal": "JudgeEqual",
     "judge_equal_list": "JudgeEqualList",
+    "judge_latex_equal":"JudgeLatexEqual",
     "judge_mc1": "JudgeMC1",
     "judge_mc2": "JudgeMC2",
 }
@@ -150,6 +154,112 @@ class JudgeEqualList(BaseTool):
     def __call__(self, data_1, data_2) -> bool:
         return self.apply(data_1, data_2)
     
+    
+# refer: https://github.com/mathllm/MATH-V/blob/main/evaluation/utils.py
+class JudgeLatexEqual(BaseTool):
+    def __init__(self):
+        super().__init__()
+
+
+    def apply(self, data_1, data_2) -> bool:
+        def eval_tuple(s):
+            """
+            Evaluates the mathematical expressions within tuples or lists represented as strings.
+            
+            Args:
+                s (str): The string representation of a tuple or list.
+                         E.g., "(a,b,c,...)" or "[a,b,c,...]"
+            
+            Returns:
+                str: A string representation of the tuple or list with evaluated expressions.
+                     Returns the original string if it doesn't match the expected format or if an error occurs.
+            
+            Example:
+                eval_tuple("(2*3, 5+2)") -> "(6,7)"
+            
+            Note:
+                This function relies on the latex2sympy function which is assumed to be defined elsewhere in the code.
+            """
+            # Split the string by commas to get individual elements
+            sl = s[1:-1].split(',')
+            
+            try:
+                # Check if string is a tuple representation and has more than one element
+                if s[0] == '(' and s[-1] == ')' and len(sl) > 1:
+                    # Evaluate each element using latex2sympy and round the result to 2 decimal places
+                    # Skip evaluation if element is 'infty', 'a', or '-a'
+                    s = ','.join([str(round(eval(str(latex2sympy(sub))),2)) 
+                                  if 'infty' not in sub and sub not in ['a', '-a'] else sub for sub in sl])
+                    return f"({s})"
+                
+                # Check if string is a list representation and has more than one element
+                elif s[0] == '[' and s[-1] == ']' and len(sl) > 1:
+                    # Same evaluation process as for tuples
+                    s = ','.join([str(round(eval(str(latex2sympy(sub))),2)) 
+                                  if 'infty' not in sub and sub not in ['a', '-a'] else sub for sub in sl])
+                    return f"[{s}]"
+            
+            except Exception:  # Catch any exceptions and return the original string
+                return s
+            
+            # Return original string if it doesn't match tuple or list format
+            return s
+
+        def is_equal(asw: str, gt_asw: str) -> bool:
+            """
+            Judge if `asw` is equivalent to `gt_asw`.
+
+            This function checks if the given answers are equivalent, considering
+            various scenarios such as tuples, lists separated by commas, and
+            mathematical equivalence in LaTeX format.
+
+            Args:
+                asw (str): The answer string to be checked.
+                gt_asw (str): The ground truth answer string to be matched against.
+
+            Returns:
+                bool: True if the answers are equivalent, otherwise False.
+
+            """
+
+            # return gt_asw == asw
+
+            # Check for empty strings after removing spaces and return False if any of them is empty.
+            asw = asw.lower()
+            gt_asw = gt_asw.lower()
+            
+            if asw.replace(' ', '') == '' or gt_asw.replace(' ', '') == '':
+                return False
+
+            if gt_asw.strip() == asw.strip():
+                return True
+           
+            # Convert the string to a tuple format.
+            asw = eval_tuple(asw)
+            gt_asw = eval_tuple(gt_asw)
+
+            # Check for simple tuple containment. Return True if one tuple is contained in the other.
+            if gt_asw == asw:
+                return True
+
+            
+
+            try:
+                # Convert LaTeX format to a sympy expression and evaluate both expressions.
+                # If the evaluated results are close enough (up to 2 decimal places), return True.
+                if round(eval(str(latex2sympy(gt_asw))), 2) == round(eval(str(latex2sympy(asw))), 2):
+                    return True
+
+                else:
+                    return False
+            except:
+                # If any error occurs during comparison, return False.
+                return False
+        
+        return is_equal(data_1, data_2)
+    
+    def __call__(self, data_1, data_2) -> bool:
+        return self.apply(data_1, data_2)
 
 class RegexMatchLetter(RegexMatch):
     def __init__(self, additional_pattern: str = None, match_index: int = None):
@@ -395,6 +505,234 @@ class RegexMatchMultiOpen(RegexMatch):
 
     def __call__(self, data: Union[List, Iterable]) -> Union[List, None]:
         return self.apply(data)
+    
+# refer: https://github.com/mathllm/MATH-V/blob/main/evaluation/utils.py
+class RegexMatchLatexMath(RegexMatch):
+    """
+    Handle multi-choice and open-ended mixed tasks.
+    """
+    def __init__(self, additional_pattern: str = None, match_index: int = None, letter_pattern: str = None):
+        super().__init__(additional_pattern, match_index)
+
+
+
+    def apply(self, data: Union[List, Iterable]) -> Union[List, None]:
+        """Process responses with both letter matching and open-ended analysis"""
+        def _fix_fracs(string):
+            # Split the string based on occurrences of '\frac'.
+            substrs = string.split("\\frac")
+            new_str = substrs[0]
+
+            # Check if there are any occurrences of '\frac' in the string.
+            if len(substrs) > 1:
+                # Exclude the part of the string before the first '\frac'.
+                substrs = substrs[1:]
+
+                for substr in substrs:
+                    new_str += "\\frac"
+                    # If the current substring already starts with a brace, 
+                    # it's likely formatted correctly.
+                    if len(substr) > 0 and substr[0] == "{":
+                        new_str += substr
+                    else:
+                        # Ensure that the substring has at least 2 characters 
+                        # for numerator and denominator.
+                        try:
+                            assert len(substr) >= 2
+                        except:
+                            return string
+
+                        a = substr[0]  # Potential numerator.
+                        b = substr[1]  # Potential denominator.
+
+                        # Check if the denominator (b) is already braced.
+                        if b != "{":
+                            if len(substr) > 2:
+                                post_substr = substr[2:]
+                                new_str += "{" + a + "}{" + b + "}" + post_substr
+                            else:
+                                new_str += "{" + a + "}{" + b + "}"
+                        else:
+                            if len(substr) > 2:
+                                post_substr = substr[2:]
+                                new_str += "{" + a + "}" + b + post_substr
+                            else:
+                                new_str += "{" + a + "}" + b
+
+            # Update the string to the newly formatted version.
+            string = new_str
+            return string
+
+        def _fix_a_slash_b(string):
+            # Check if the string contains exactly one slash, which may indicate it's a fraction.
+            if len(string.split("/")) != 2:
+                return string
+
+            # Split the string by slash to extract potential numerator and denominator.
+            a, b = string.split("/")
+
+            try:
+                # Try to convert the parts to integers.
+                a = int(a)
+                b = int(b)
+
+                # Check if the string is in the expected format after conversion.
+                assert string == "{}/{}".format(a, b)
+
+                # Convert the fraction to LaTeX representation.
+                new_string = "\\frac{" + str(a) + "}{" + str(b) + "}"
+                return new_string
+
+            # Handle exceptions for non-integer fractions or other unexpected formats.
+            except:
+                return string
+
+        def _remove_right_units(string):
+            # Split the string using "\\text{ " as the delimiter.
+            splits = string.split("\\text{ ")
+            
+            # Return the part of the string before the last occurrence of "\\text{ ".
+            return splits[0]
+
+        def _fix_sqrt(string):
+            # Check if "\sqrt" is not in the string. If not, return the string as is.
+            if "\\sqrt" not in string:
+                return string
+
+            # Split the string based on the "\sqrt" substring.
+            splits = string.split("\\sqrt")
+            
+            # The initial portion of the string before the first occurrence of "\sqrt".
+            new_string = splits[0]
+
+            # Loop through each split portion (after the initial one).
+            for split in splits[1:]:
+                # If the split portion is non-empty and the first character isn't a '{',
+                # then it means the argument of the sqrt is not enclosed in braces.
+                if len(split) > 0 and split[0] != "{":
+                    a = split[0]
+                    # Add braces around the first character and append the rest of the split portion.
+                    new_substr = "\\sqrt{" + a + "}" + split[1:]
+                else:
+                    # If the split portion starts with a '{', then it's already correct.
+                    new_substr = "\\sqrt" + split
+                # Add the new substring to our result string.
+                new_string += new_substr
+
+            return new_string
+
+        def _strip_string(string):
+            # Remove linebreaks
+            string = string.replace("\n", "")
+
+            # Remove inverse spaces
+            string = string.replace("\\!", "")
+
+            # Replace double backslashes with a single backslash
+            string = string.replace("\\\\", "\\")
+
+            # Replace tfrac and dfrac with frac
+            string = string.replace("tfrac", "frac")
+            string = string.replace("dfrac", "frac")
+
+            # Remove \left and \right LaTeX commands
+            string = string.replace("\\left", "")
+            string = string.replace("\\right", "")
+
+            # Remove degree notation
+            string = string.replace("^{\\circ}", "")
+            string = string.replace("^\\circ", "")
+
+            # Remove dollar signs (potentially used for inline math in LaTeX)
+            string = string.replace("\\$", "")
+            string = string.replace("$", "")
+
+            # Remove units (assumed to be on the right). Note: The function _remove_right_units is not provided.
+            string = _remove_right_units(string)
+
+            # Remove percentage notations
+            string = string.replace("\\%", "")
+            string = string.replace("\%", "")
+
+            # Handle floating numbers starting with "."
+            string = string.replace(" .", " 0.")
+            string = string.replace("{.", "{0.")
+            if len(string) == 0:
+                return string
+            if string[0] == ".":
+                string = "0" + string
+
+            # If there are equalities or approximations, only consider the value after them
+            if len(string.split("=")) == 2:
+                string = string.split("=")[-1]
+            if len(string.split("\\approx")) == 2:
+                string = string.split("\\approx")[-1]
+
+            # Fix sqrt values not wrapped in curly braces. Note: The function _fix_sqrt is not provided.
+            if 'sqrt' in string:
+                string = _fix_sqrt(string)
+
+            # Remove all spaces
+            string = string.replace(" ", "")
+
+            # Transform certain fraction notations to the desired format. Note: The function _fix_fracs is not provided.
+            if 'sqrt' in string:
+                string = _fix_fracs(string)
+
+            # Convert 0.5 to its fraction representation
+            if string == "0.5":
+                string = "\\frac{1}{2}"
+
+            # Fix fractions represented with a slash. Note: The function _fix_a_slash_b is not provided.
+            string = _fix_a_slash_b(string)
+
+            return string
+
+        def find_math_answer(s: str) -> str:
+            s = s.lower()
+            if '{}' in s:
+                s = s.replace('{}', '')
+
+            try:
+                pattern = re.compile('oxed{(.*)}', flags=re.S)
+                ans = pattern.findall(s)[-1]
+            except:     
+                ans = s  # If the pattern is not found, consider the entire string as the answer.
+
+            # If there's a closing bracket without an opening bracket before it, consider everything before it.
+            if ans.find('}') != -1 and (ans.find('{') == -1 or  ans.find('}') < ans.find('{')):
+                ans = ans.split('}')[0]
+
+            # Extract the value after the equals sign or approx symbol.
+            ans = ans.split('=')[-1]
+            ans = ans.split('\\approx')[-1]
+
+            # Clean the string from various LaTeX formatting.
+            ans = ans.replace(" ", "").replace("\\,", "").replace('∞', '\\infty')
+            ans = ans.replace("+\infty", "\infty").replace("\\\\", "\\").replace("\n", "")
+            ans = ans.replace('\\text', '').replace('\\mbox', '').replace('bmatrix', 'pmatrix')
+            ans = ans.replace("\\left", "").replace('\\right', '').replace("^{\\circ}", "")
+            ans = ans.replace("^\\circ", "").replace("{m}^3", "").replace("m^3", "")
+            ans = ans.replace("{units}", "").replace("units", "").replace("{km}", "").replace("km", "")
+
+            return _strip_string(ans)         
+        
+
+        
+        try:
+            def process_single_response(response: str) -> List:
+                response = '\\boxed{' + response.split('oxed{')[-1]
+                response = find_math_answer(response).replace('(a)', 'a').replace('(b)', 'b').replace('(c)', 'c').replace('(d)', 'd').replace('(e)', 'e').replace('{a}', 'a').replace('{b}', 'b').replace('{c}', 'c').replace('{d}', 'd').replace('{e}', 'e').rstrip('.').lstrip(':').strip()
+                return response
+            return [process_single_response(response) for response in data]
+        except Exception as e:
+            print(f"Error processing responses: {e}")
+            return None
+
+    def __call__(self, data: Union[List, Iterable]) -> Union[List, None]:
+        return self.apply(data)
+
+    
     
 class JudgeMC1(BaseTool):
     def __init__(self):

--- a/eval_anything/utils/utils.py
+++ b/eval_anything/utils/utils.py
@@ -36,6 +36,7 @@ BENCHMARK_MODALITY_MAP = {
     'agieval': 'text_to_text',
     'beavertails': 'text_to_text',
     'mmmu': 'text_image_to_text',
+    'mathvision': 'text_image_to_text',
 }
 
 class MultiChoicePromptBuilder():

--- a/output
+++ b/output
@@ -1,0 +1,1 @@
+/aifs4su/hansirui/pcwen_output/eval_any/output/

--- a/output
+++ b/output
@@ -1,1 +1,0 @@
-/aifs4su/hansirui/pcwen_output/eval_any/output/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "clip",
     "pytorch_fid",
     "av",
+    "latex2sympy2",
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
# Description
Add new benchmark [MathVision](https://mathllm.github.io/mathvision/)


The MathVision was published at February 2024. At that time, they only tested a few closed-source models. Their [leaderboard](https://mathllm.github.io/mathvision/#leaderboard)  directly adopted scores reported by models like Qwen without their own secondary verification.

Their code does not include prompts or hyperparameter settings for existing models.

Regarding prompts, we use the prompt for Qwen-VL-Max from their MathVision GitHub.

Current test results are as follows:
For Qwen/Qwen2.5-VL-72B-Instruct, Qwen's official score is 38.1
Using greedy decoding, I achieved a score of 0.357565789473684

For Qwen/Qwen2-VL-72B-Instruct, Qwen's official score is 25.9
Using greedy decoding, I achieved a score of 0.22401315789473683

The differences are around three points, so I consider this acceptable.



## Motivation and Context
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax close #1314520 if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/PKU-Alignment/align-anything/issues) for new features and bug fixes)
## Types of changes
What types of changes does your code introduce? Put an x in all the boxes that apply:

 - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds core functionality)
-  [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation (update in the documentation)
## Checklist
Go over all the following points, and put an x in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

  - [x] I have read the [CONTRIBUTION](https://github.com/PKU-Alignment/align-anything/blob/HEAD/.github/CONTRIBUTING.md) guide. (required)
  - [ ] My change requires a change to the documentation.
 - [ ] I have updated the tests accordingly. (required for a bug fix or a new feature)
 - [ ] I have updated the documentation accordingly.





